### PR TITLE
UI updates and filter fixes in PO/Report and admin modules

### DIFF
--- a/app/Http/Controllers/POController.php
+++ b/app/Http/Controllers/POController.php
@@ -61,8 +61,13 @@ class POController extends Controller
                 ? $query->whereBetween('doc_date', [$value, request('doc_date_to')])
                 : $query->whereDate('doc_date', $value),
             'deliv_date_from' => fn ($value) => request('deliv_date_to')
-                ? $query->whereBetween('deliv_date', [$value, request('deliv_date_to')])
-                : $query->whereDate('deliv_date', $value),
+                ? $query->whereHas('pomaterials', function ($q) use ($value) {
+                    $to = request('deliv_date_to');
+                    $q->whereBetween('del_date', [$value, $to]);
+                })
+                : $query->whereHas('pomaterials', function ($q) use ($value) {
+                    $q->whereDate('del_date', $value);
+                }),
             'status'     => fn ($value) => $query->where('status', 'ilike', "%{$value}%"),
             'control_no' => fn ($value) => $value === 'blank'
                 ? $query->whereNull('control_no')

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -242,8 +242,8 @@ class ReportController extends Controller
                 ? $query->whereBetween('po_headers.doc_date', [$value, $request->input('doc_date_to')])
                 : $query->where('po_headers.doc_date', 'ilike', "%{$value}%"),
             'deliv_date_from' => fn ($value) => $request->input('deliv_date_to')
-                ? $query->whereBetween('po_headers.deliv_date', [$value, $request->input('deliv_date_to')])
-                : $query->where('po_headers.deliv_date', 'ilike', "%{$value}%"),
+                ? $query->whereBetween('po_materials.del_date', [$value, $request->input('deliv_date_to')])
+                : $query->whereDate('po_materials.del_date', $value),
             'ponumber_from' => fn ($value) => $request->input('ponumber_to')
                 ? $query->whereBetween('po_headers.po_number', [$value, $request->input('ponumber_to')])
                 : $query->where('po_headers.po_number', 'ilike', "%{$value}%"),
@@ -478,8 +478,8 @@ class ReportController extends Controller
             'short_text' => fn ($value) => $query->where(fn (Builder $q) => $q->where('pr_materials.short_text', 'ilike', "%{$value}%")
                 ->orwhere('po_materials.short_text', 'ilike', "%{$value}%")),
             'deliv_date_from' => fn ($value) => $request->input('deliv_date_to')
-                ? $query->whereBetween('po_headers.deliv_date', [$value, $request->input('deliv_date_to')])
-                : $query->where('po_headers.deliv_date', 'ilike', "%{$value}%"),
+                ? $query->whereBetween('po_materials.del_date', [$value, $request->input('deliv_date_to')])
+                : $query->whereDate('po_materials.del_date', $value),
             'open_po' => fn ($value) => $query->where('po_materials.po_gr_qty', '>', 0),
             'open_pr' => fn ($value) => $query->where('pr_materials.qty_open', '>', 0),
             'plant'   => fn ($value) => $query->where('pr_headers.plant', $value),

--- a/app/Services/MenuService.php
+++ b/app/Services/MenuService.php
@@ -148,7 +148,7 @@ class MenuService
                         'href'        => route('approver.index'),
                     ],
                     [
-                        'label'       => 'Purchase Groups',
+                        'label'       => 'Material Purchasing Groups',
                         'permissions' => $user->can(PermissionsEnum::Admin),
                         'href'        => route('purchgrp.index'),
                     ],

--- a/resources/js/Pages/Admin/PurchGroup/Index.tsx
+++ b/resources/js/Pages/Admin/PurchGroup/Index.tsx
@@ -62,7 +62,7 @@ export default function Index({
       menus={auth.menu}
       header={
         <div className="flex flex-row justify-between">
-          <h2 className="font-semibold text-xl text-gray-800 leading-tight">Purchase Groups</h2>
+          <h2 className="font-semibold text-xl text-gray-800 leading-tight">Material Purchasing Groups</h2>
           <div className="flex gap-2"></div>
           <Create procgrps={procgrps} prctrlgrp={prctrlgrp} plants={plants} />
         </div>

--- a/resources/js/Pages/PO/Create.tsx
+++ b/resources/js/Pages/PO/Create.tsx
@@ -73,10 +73,10 @@ const Create = ({
 
   const columns = useMemo(
     () => [
-      { ...keyColumn('sel', checkboxColumn), title: 'Sel', minWidth: 30 },
-      { ...keyColumn('status', textColumn), title: 'Sts', minWidth: 35, disabled: true },
+      // { ...keyColumn('sel', checkboxColumn), title: 'Sel', minWidth: 30 },
+      // { ...keyColumn('status', textColumn), title: 'Sts', minWidth: 35, disabled: true },
       { ...keyColumn('item_no', intColumn), title: 'ItmNo', minWidth: 55, disabled: true },
-      { ...keyColumn('mat_code', textColumn), title: 'Material', minWidth: 120, disabled: true },
+      { ...keyColumn('mat_code', textColumn), title: 'Material', minWidth: 120, disabled: true  },
       { ...keyColumn('short_text', textColumn), title: 'Material Description', minWidth: 400, disabled: true },
       {
         ...keyColumn(


### PR DESCRIPTION
-Renamed "Purchasing Group" page to "Material Purchasing Group" in the Admin section.
-Fixed the Material Delivery Date filter in the PO module, including PO Report and PO History pages. 
-Removed "Sel" and "Sts" columns from the Create PO view to simplify the interface. 
-Added "Submit" and "Discard" buttons for disabled states in PR Edit for better user interaction and control.